### PR TITLE
ci(pydantic-compat): pydantic v1/v2 compatibility, manifest hardening, strictere CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,49 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements*.txt') }}
+      - name: Install dev dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
+      - name: Lint (ruff)
+        run: ruff check .
+      - name: Type check (mypy)
+        run: mypy src
+      - name: Run tests (pytest)
+        run: |
+          pytest -q --junitxml=pytest-report.xml
+      - name: Upload test report
+        uses: actions/upload-artifact@v4
+        with:
+          name: pytest-report
+          path: pytest-report.xml
+      - name: Pip audit (blocking)
+        run: pip-audit --strict
+name: CI
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+    branches: [ main, master ]
+
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.11]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
       - name: Debug runner info
         run: |
           echo "--- runner info ---"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,14 @@
 repos:
-    - repo: https://github.com/psf/black
-        rev: 24.3.0
-        hooks:
-            - id: black
-    - repo: https://github.com/charliermarsh/ruff-pre-commit
-        rev: v0.13.0
-        hooks:
-            - id: ruff
-    - repo: https://github.com/pre-commit/mirrors-mypy
-        rev: v1.6.1
-        hooks:
-            - id: mypy
+  - repo: https://github.com/psf/black
+    rev: 24.3.0
+    hooks:
+      - id: black
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: v0.13.0
+    hooks:
+      - id: ruff
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.6.1
+    hooks:
+      - id: mypy
+        files: ^(src|tests)/

--- a/.pre-commit-config.yaml.new
+++ b/.pre-commit-config.yaml.new
@@ -1,0 +1,13 @@
+repos:
+    - repo: https://github.com/psf/black
+        rev: 24.3.0
+        hooks:
+            - id: black
+    - repo: https://github.com/charliermarsh/ruff-pre-commit
+        rev: v0.13.0
+        hooks:
+            - id: ruff
+    - repo: https://github.com/pre-commit/mirrors-mypy
+        rev: v1.6.1
+        hooks:
+            - id: mypy

--- a/README.md
+++ b/README.md
@@ -12,6 +12,26 @@ python -m venv .venv; .\.venv\Scripts\Activate.ps1; pip install -r requirements.
 
 2. Run the pipeline with the example config:
 
+Developer notes — pre-commit
+----------------------------
+
+We use pre-commit to enforce formatting and basic checks locally. To run the hooks locally:
+
+```powershell
+python -m pip install --user pre-commit
+python -m pre_commit install
+python -m pre_commit run --all-files
+```
+
+If you modify dependencies, update `requirements-dev.txt` and run `pip install -r requirements-dev.txt`.
+
+CHANGELOG
+---------
+
+Unreleased
+- Added deterministic manifests with environment sidecar and manifest SHA provenance.
+- Tightened CI: mypy and pip-audit are now blocking; pytest reports are uploaded as artifacts.
+
 ```powershell
 python -m src.main --config ./example-configs/example-config-s1.yaml
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,10 @@
 [tool.ruff]
 line-length = 88
 # Keep defaults but ensure stable formatting across devs
-extend-ignore = ["E402"]
 exclude = [".venv", "build", "dist", "tests/fixtures"]
+
+[tool.ruff.lint]
+extend-ignore = ["E402"]
 
 [tool.black]
 line-length = 88

--- a/scripts/ci_fixture_run.py
+++ b/scripts/ci_fixture_run.py
@@ -6,6 +6,7 @@ Behavior:
 
 This script is intentionally conservative: it doesn't change library code and only monkeypatches behavior at runtime.
 """
+
 import os
 import sys
 import json
@@ -73,8 +74,16 @@ def main(config_path: str = None):
                     all_df = []
                     logs = []
                     for ind in indicators:
-                        ind_id = ind.get("id") if isinstance(ind, dict) else getattr(ind, "id", None)
-                        code = ind.get("code") if isinstance(ind, dict) else getattr(ind, "code", None)
+                        ind_id = (
+                            ind.get("id")
+                            if isinstance(ind, dict)
+                            else getattr(ind, "id", None)
+                        )
+                        code = (
+                            ind.get("code")
+                            if isinstance(ind, dict)
+                            else getattr(ind, "code", None)
+                        )
                         for c in countries:
                             got = load_fixture(code or ind_id, c)
                             if got is None:
@@ -91,7 +100,18 @@ def main(config_path: str = None):
                             all_df.append(df)
                             logs.extend(lg)
                     if not all_df:
-                        return pd.DataFrame(columns=["source", "indicator", "country", "date", "value"]), logs
+                        return (
+                            pd.DataFrame(
+                                columns=[
+                                    "source",
+                                    "indicator",
+                                    "country",
+                                    "date",
+                                    "value",
+                                ]
+                            ),
+                            logs,
+                        )
                     return pd.concat(all_df, ignore_index=True), logs
 
             mod.WorldBankFetcher = FixtureWB

--- a/scripts/example_run.py
+++ b/scripts/example_run.py
@@ -2,6 +2,7 @@
 
 Produces outputs in ./output and manifest in data/_artifacts for quick inspection.
 """
+
 import os
 from datetime import datetime
 import pandas as pd
@@ -10,6 +11,7 @@ import numpy as np
 # ensure repo root
 ROOT = os.path.dirname(os.path.dirname(__file__))
 import sys
+
 sys.path.insert(0, ROOT)
 
 from src.io.artifacts import write_manifest
@@ -21,9 +23,17 @@ cfg = {
     "countries": ["USA", "DEU", "FRA", "JPN", "BRA"],
     "indicators": [
         # indicator id, good_direction is up by default
-        type("I", (), {"id": "gdp_growth", "transform": "none", "good_direction": "up"}),
-        type("I", (), {"id": "inflation", "transform": "none", "good_direction": "down"}),
-        type("I", (), {"id": "unemployment", "transform": "none", "good_direction": "down"}),
+        type(
+            "I", (), {"id": "gdp_growth", "transform": "none", "good_direction": "up"}
+        ),
+        type(
+            "I", (), {"id": "inflation", "transform": "none", "good_direction": "down"}
+        ),
+        type(
+            "I",
+            (),
+            {"id": "unemployment", "transform": "none", "good_direction": "down"},
+        ),
     ],
     "scoring": {
         "weights": {"gdp_growth": 0.5, "inflation": 0.25, "unemployment": 0.25},
@@ -44,14 +54,23 @@ for ind in cfg["indicators"]:
     for c in cfg["countries"]:
         val = np.random.randn() + (0.5 if ind.id == "gdp_growth" else 0.0)
         # inflation: higher is bad, unemployment higher is bad
-        rows.append({"country": c, "indicator": ind.id, "date": datetime.utcnow().date().isoformat(), "value": float(val)})
+        rows.append(
+            {
+                "country": c,
+                "indicator": ind.id,
+                "date": datetime.utcnow().date().isoformat(),
+                "value": float(val),
+            }
+        )
 
 raw_df = pd.DataFrame(rows)
 # apply a simple "standardize" placeholder
 indicators = []
 for ind in cfg["indicators"]:
     df = raw_df[raw_df["indicator"] == ind.id].copy()
-    df["value_std"] = (df["value"] - df["value"].mean()) / (df["value"].std(ddof=0) or 1.0)
+    df["value_std"] = (df["value"] - df["value"].mean()) / (
+        df["value"].std(ddof=0) or 1.0
+    )
     df.loc[df["indicator"] == ind.id, "indicator"] = ind.id
     indicators.append(df[["country", "indicator", "date", "value", "value_std"]])
 indicators_df = pd.concat(indicators, ignore_index=True)
@@ -59,7 +78,9 @@ indicators_df = pd.concat(indicators, ignore_index=True)
 pivot = indicators_df.pivot(index="country", columns="indicator", values="value_std")
 
 # compute composite with coverage penalty
-scores = compute_composite(pivot, cfg["scoring"]["weights"], apply_coverage_penalty=True, coverage_k=1.0)
+scores = compute_composite(
+    pivot, cfg["scoring"]["weights"], apply_coverage_penalty=True, coverage_k=1.0
+)
 
 # rank
 ranked = scores.sort_values(ascending=False).to_frame(name="score")

--- a/scripts/inspect_outputs.py
+++ b/scripts/inspect_outputs.py
@@ -3,48 +3,55 @@ import os
 import pandas as pd
 
 ROOT = os.path.dirname(os.path.dirname(__file__))
-OUT_DIR = os.path.join(ROOT, 'output')
-ART_DIR = os.path.join(ROOT, 'data', '_artifacts')
-CSV = os.path.join(OUT_DIR, 'macro_ranking_170.csv')
-XLSX = os.path.join(OUT_DIR, 'macro_ranking_170.xlsx')
+OUT_DIR = os.path.join(ROOT, "output")
+ART_DIR = os.path.join(ROOT, "data", "_artifacts")
+CSV = os.path.join(OUT_DIR, "macro_ranking_170.csv")
+XLSX = os.path.join(OUT_DIR, "macro_ranking_170.xlsx")
 
-print('Looking for output files...')
+print("Looking for output files...")
 for p in (CSV, XLSX):
-    print('  ', p, '->', 'EXISTS' if os.path.exists(p) else 'MISSING')
+    print("  ", p, "->", "EXISTS" if os.path.exists(p) else "MISSING")
 
 if os.path.exists(CSV):
     df = pd.read_csv(CSV)
-    print('\nCSV shape:', df.shape)
-    if 'country' in df.columns:
-        print('Unique countries:', df['country'].nunique())
-        print('Duplicate country rows:', df.duplicated(subset=['country']).sum())
+    print("\nCSV shape:", df.shape)
+    if "country" in df.columns:
+        print("Unique countries:", df["country"].nunique())
+        print("Duplicate country rows:", df.duplicated(subset=["country"]).sum())
     else:
-        print('Note: no `country` column in CSV')
-    print('\nTop 10 rows by score (if present):')
-    if 'score' in df.columns:
-        print(df.sort_values('score', ascending=False).head(10).to_string(index=False))
+        print("Note: no `country` column in CSV")
+    print("\nTop 10 rows by score (if present):")
+    if "score" in df.columns:
+        print(df.sort_values("score", ascending=False).head(10).to_string(index=False))
     else:
         print(df.head(10).to_string(index=False))
 
 if os.path.exists(XLSX):
     df2 = pd.read_excel(XLSX, sheet_name=0)
-    print('\nXLSX shape:', df2.shape)
+    print("\nXLSX shape:", df2.shape)
 
 # list manifests
-print('\nArtifacts directory:', ART_DIR)
+print("\nArtifacts directory:", ART_DIR)
 if os.path.isdir(ART_DIR):
-    mfiles = sorted([os.path.join(ART_DIR, f) for f in os.listdir(ART_DIR) if f.endswith('.json')])
-    print('Found manifests:', len(mfiles))
+    mfiles = sorted(
+        [os.path.join(ART_DIR, f) for f in os.listdir(ART_DIR) if f.endswith(".json")]
+    )
+    print("Found manifests:", len(mfiles))
     if mfiles:
         latest = mfiles[-1]
-        print('Latest manifest:', latest)
+        print("Latest manifest:", latest)
         try:
-            with open(latest, 'r', encoding='utf-8') as fh:
+            with open(latest, "r", encoding="utf-8") as fh:
                 mf = json.load(fh)
             keys = list(mf.keys())
-            print('Manifest keys:', keys)
-            print('Manifest snapshot: n_rows=', mf.get('n_rows'), 'outputs=', mf.get('outputs'))
+            print("Manifest keys:", keys)
+            print(
+                "Manifest snapshot: n_rows=",
+                mf.get("n_rows"),
+                "outputs=",
+                mf.get("outputs"),
+            )
         except Exception as e:
-            print('Failed reading manifest:', e)
+            print("Failed reading manifest:", e)
 else:
-    print('No artifacts directory found')
+    print("No artifacts directory found")

--- a/scripts/manifest_latest.py
+++ b/scripts/manifest_latest.py
@@ -3,18 +3,22 @@ import json
 
 ART = os.path.join(os.path.dirname(os.path.dirname(__file__)), "data", "_artifacts")
 
+
 def latest_manifest():
-    files = sorted([os.path.join(ART, f) for f in os.listdir(ART) if f.endswith('.json')])
+    files = sorted(
+        [os.path.join(ART, f) for f in os.listdir(ART) if f.endswith(".json")]
+    )
     if not files:
-        print('No manifests found')
+        print("No manifests found")
         return
     path = files[-1]
-    print('Latest manifest:', path)
-    with open(path, encoding='utf-8') as fh:
+    print("Latest manifest:", path)
+    with open(path, encoding="utf-8") as fh:
         j = json.load(fh)
-    print('Keys:', list(j.keys()))
-    print('Env hash:', j.get('environment', {}).get('env_hash'))
-    print('Fetches:', len(j.get('fetches', [])))
+    print("Keys:", list(j.keys()))
+    print("Env hash:", j.get("environment", {}).get("env_hash"))
+    print("Fetches:", len(j.get("fetches", [])))
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     latest_manifest()

--- a/scripts/run_170.py
+++ b/scripts/run_170.py
@@ -44,12 +44,14 @@ def run_batches(countries, batch_size=20, run=False, cleanup=True, out_dir=None)
     combined_xlsx = os.path.join(out_dir, f"macro_ranking_{len(countries)}.xlsx")
     combined_csv = os.path.join(out_dir, f"macro_ranking_{len(countries)}.csv")
 
-    existing_files = set([f for f in os.listdir(out_dir) if f.endswith('.xlsx')])
+    existing_files = set([f for f in os.listdir(out_dir) if f.endswith(".xlsx")])
     collected = []
 
     for i, batch in enumerate(chunk(countries, batch_size), start=1):
-        cs = ','.join(batch)
-        print(f"Batch {i}/{(len(countries)+batch_size-1)//batch_size}: {len(batch)} countries")
+        cs = ",".join(batch)
+        print(
+            f"Batch {i}/{(len(countries)+batch_size-1)//batch_size}: {len(batch)} countries"
+        )
         if not run:
             print("  Dry-run: would call main with countries:", cs)
             continue
@@ -61,7 +63,7 @@ def run_batches(countries, batch_size=20, run=False, cleanup=True, out_dir=None)
             continue
 
         # detect any new xlsx files produced by the run
-        files = [f for f in os.listdir(out_dir) if f.endswith('.xlsx')]
+        files = [f for f in os.listdir(out_dir) if f.endswith(".xlsx")]
         new_files = [os.path.join(out_dir, f) for f in files if f not in existing_files]
         if not new_files:
             print("  Warning: no new .xlsx produced for this batch")
@@ -95,43 +97,58 @@ def run_batches(countries, batch_size=20, run=False, cleanup=True, out_dir=None)
 
     combined = pd.concat(collected, ignore_index=True)
     # keep highest score per country if available
-    if 'score' in combined.columns and 'country' in combined.columns:
-        combined = combined.sort_values('score', ascending=False).drop_duplicates(subset=['country'], keep='first')
+    if "score" in combined.columns and "country" in combined.columns:
+        combined = combined.sort_values("score", ascending=False).drop_duplicates(
+            subset=["country"], keep="first"
+        )
     combined = combined.reset_index(drop=True)
 
     try:
         combined.to_excel(combined_xlsx, index=False)
         combined.to_csv(combined_csv, index=False)
-        print('Wrote combined Excel to', combined_xlsx)
-        print('Wrote combined CSV to', combined_csv)
+        print("Wrote combined Excel to", combined_xlsx)
+        print("Wrote combined CSV to", combined_csv)
     except Exception as e:
-        print('Failed to write combined outputs:', e)
+        print("Failed to write combined outputs:", e)
 
     manifest = {
-        'timestamp': datetime.utcnow().isoformat(),
-        'fetch_summary': {'batches': len(collected)},
-        'fetches': [],
-        'n_rows': int(combined.shape[0]),
-        'config_snapshot': {'countries': countries}
+        "timestamp": datetime.utcnow().isoformat(),
+        "fetch_summary": {"batches": len(collected)},
+        "fetches": [],
+        "n_rows": int(combined.shape[0]),
+        "config_snapshot": {"countries": countries},
     }
     try:
-        write_manifest(manifest, outputs={'excel': combined_xlsx, 'csv': combined_csv})
-        print('Wrote manifest to data/_artifacts (see latest)')
+        write_manifest(manifest, outputs={"excel": combined_xlsx, "csv": combined_csv})
+        print("Wrote manifest to data/_artifacts (see latest)")
     except Exception as e:
-        print('Failed to write manifest:', e)
+        print("Failed to write manifest:", e)
 
 
 def parse_args_and_run():
     parser = argparse.ArgumentParser()
-    parser.add_argument('--run', action='store_true', help='Execute batches (default is dry-run)')
-    parser.add_argument('--batch-size', type=int, default=20, help='Number of countries per batch')
-    parser.add_argument('--no-cleanup', action='store_true', help='Do not delete per-batch output files')
-    parser.add_argument('--n', type=int, default=170, help='Number of countries to include (first N from pycountry)')
+    parser.add_argument(
+        "--run", action="store_true", help="Execute batches (default is dry-run)"
+    )
+    parser.add_argument(
+        "--batch-size", type=int, default=20, help="Number of countries per batch"
+    )
+    parser.add_argument(
+        "--no-cleanup", action="store_true", help="Do not delete per-batch output files"
+    )
+    parser.add_argument(
+        "--n",
+        type=int,
+        default=170,
+        help="Number of countries to include (first N from pycountry)",
+    )
     args = parser.parse_args()
 
     countries = list_countries(n=args.n)
-    run_batches(countries, batch_size=args.batch_size, run=args.run, cleanup=not args.no_cleanup)
+    run_batches(
+        countries, batch_size=args.batch_size, run=args.run, cleanup=not args.no_cleanup
+    )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     parse_args_and_run()

--- a/scripts/run_70.py
+++ b/scripts/run_70.py
@@ -3,8 +3,10 @@
 This script prepends the repository root to sys.path so `src` can be imported
 when run from the scripts folder.
 """
+
 import os
 import sys
+
 ROOT = os.path.dirname(os.path.dirname(__file__))
 sys.path.insert(0, ROOT)
 
@@ -12,5 +14,5 @@ import pycountry
 from src.main import main
 
 countries = [c.alpha_3 for c in list(pycountry.countries)[:70]]
-print('Running pipeline for', len(countries), 'countries')
-main(['--countries', ','.join(countries)])
+print("Running pipeline for", len(countries), "countries")
+main(["--countries", ",".join(countries)])

--- a/scripts/run_75_msci.py
+++ b/scripts/run_75_msci.py
@@ -3,8 +3,10 @@
 This script reuses the batching runner to execute the pipeline for a curated ISO3 list and
 produces a combined Excel + CSV and manifest in output/ and data/_artifacts/.
 """
+
 import os
 import sys
+
 ROOT = os.path.dirname(os.path.dirname(__file__))
 sys.path.insert(0, ROOT)
 
@@ -13,17 +15,86 @@ from scripts.run_170 import run_batches
 # Curated ~75 countries (ISO3) with equity markets / ETF coverage. This list is conservative
 # and includes developed markets, large emerging markets and a selection of other markets.
 COUNTRIES = [
-    'USA','CAN','MEX','BRA','ARG','COL','CHL','PER',
-    'GBR','IRL','FRA','DEU','ITA','ESP','NLD','BEL','LUX','SWE','NOR','DNK','FIN','AUT','CHE','PRT','GRC',
-    'POL','CZE','HUN','ROU','TUR','KWT','SAU','QAT','ARE','ISR','EGY','ZAF',
-    'KOR','JPN','TWN','HKG','SGP','AUS','NZL','IND','CHN','IDN','MYS','THA','PHL','VNM',
-    'KAZ','LKA','NGA','KEN','MAR','EST','LTU','LVA','SVN','SVK','HRV','SRB','BGR','CYP','MLT','ISL',
-    'URY','ECU','BOL','PAN','CRI','DOM','PRY','JAM'
+    "USA",
+    "CAN",
+    "MEX",
+    "BRA",
+    "ARG",
+    "COL",
+    "CHL",
+    "PER",
+    "GBR",
+    "IRL",
+    "FRA",
+    "DEU",
+    "ITA",
+    "ESP",
+    "NLD",
+    "BEL",
+    "LUX",
+    "SWE",
+    "NOR",
+    "DNK",
+    "FIN",
+    "AUT",
+    "CHE",
+    "PRT",
+    "GRC",
+    "POL",
+    "CZE",
+    "HUN",
+    "ROU",
+    "TUR",
+    "KWT",
+    "SAU",
+    "QAT",
+    "ARE",
+    "ISR",
+    "EGY",
+    "ZAF",
+    "KOR",
+    "JPN",
+    "TWN",
+    "HKG",
+    "SGP",
+    "AUS",
+    "NZL",
+    "IND",
+    "CHN",
+    "IDN",
+    "MYS",
+    "THA",
+    "PHL",
+    "VNM",
+    "KAZ",
+    "LKA",
+    "NGA",
+    "KEN",
+    "MAR",
+    "EST",
+    "LTU",
+    "LVA",
+    "SVN",
+    "SVK",
+    "HRV",
+    "SRB",
+    "BGR",
+    "CYP",
+    "MLT",
+    "ISL",
+    "URY",
+    "ECU",
+    "BOL",
+    "PAN",
+    "CRI",
+    "DOM",
+    "PRY",
+    "JAM",
 ]
 
 # dedupe and ensure we have 75 or fewer
 COUNTRIES = list(dict.fromkeys(COUNTRIES))[:75]
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     # run in 3 batches of 25
     run_batches(COUNTRIES, batch_size=25, run=True, cleanup=True)

--- a/scripts/show_results.py
+++ b/scripts/show_results.py
@@ -2,24 +2,28 @@ import pandas as pd
 import json
 import itertools
 
-EXCEL = 'output/macro_ranking_20250927T143949Z.xlsx'
-MANIFEST = 'data/_artifacts/manifest_20250927T143949Z.json'
+EXCEL = "output/macro_ranking_20250927T143949Z.xlsx"
+MANIFEST = "data/_artifacts/manifest_20250927T143949Z.json"
 
-print('Loading', EXCEL)
+print("Loading", EXCEL)
 df = pd.read_excel(EXCEL, sheet_name=0)
-print('\n--- Ranking (full) ---\n')
+print("\n--- Ranking (full) ---\n")
 print(df.to_string(index=False))
 
-print('\n--- Manifest Summary ---\n')
-with open(MANIFEST, 'r', encoding='utf-8') as fh:
+print("\n--- Manifest Summary ---\n")
+with open(MANIFEST, "r", encoding="utf-8") as fh:
     m = json.load(fh)
 
-print('manifest_path:', MANIFEST)
-print('run_id:', m.get('run_id'))
-print('manifest_signature:', m.get('manifest_signature'))
-print('n_rows:', m.get('n_rows'))
-print('fetch_summary:', m.get('fetch_summary'))
-print('outputs:', m.get('outputs'))
-print('fetches_count:', len(m.get('fetches', [])))
-print('\nfirst 10 fetch entries:\n')
-print(json.dumps(list(itertools.islice(m.get('fetches', []), 10)), indent=2, ensure_ascii=False))
+print("manifest_path:", MANIFEST)
+print("run_id:", m.get("run_id"))
+print("manifest_signature:", m.get("manifest_signature"))
+print("n_rows:", m.get("n_rows"))
+print("fetch_summary:", m.get("fetch_summary"))
+print("outputs:", m.get("outputs"))
+print("fetches_count:", len(m.get("fetches", [])))
+print("\nfirst 10 fetch entries:\n")
+print(
+    json.dumps(
+        list(itertools.islice(m.get("fetches", []), 10)), indent=2, ensure_ascii=False
+    )
+)

--- a/src/backtest/simple.py
+++ b/src/backtest/simple.py
@@ -2,7 +2,12 @@ import pandas as pd
 from typing import Dict, Iterable, Optional
 
 
-def compute_rebalanced_weights(signals: pd.DataFrame, top_n: Optional[int] = None, min_alloc: float = 0.0, max_alloc: float = 1.0) -> Dict[pd.Timestamp, pd.Series]:
+def compute_rebalanced_weights(
+    signals: pd.DataFrame,
+    top_n: Optional[int] = None,
+    min_alloc: float = 0.0,
+    max_alloc: float = 1.0,
+) -> Dict[pd.Timestamp, pd.Series]:
     """
     Given a DataFrame `signals` indexed by date with columns as assets and values as scores,
     compute target weights at each date by converting scores to weights via proportional allocation.
@@ -13,7 +18,9 @@ def compute_rebalanced_weights(signals: pd.DataFrame, top_n: Optional[int] = Non
 
     for dt, row in signals.iterrows():
         try:
-            weights = score_to_weights(row, min_alloc=min_alloc, max_alloc=max_alloc, top_n=top_n)
+            weights = score_to_weights(
+                row, min_alloc=min_alloc, max_alloc=max_alloc, top_n=top_n
+            )
         except Exception:
             # fallback: equal weights among non-nulls
             vals = row.dropna()
@@ -28,7 +35,11 @@ def compute_rebalanced_weights(signals: pd.DataFrame, top_n: Optional[int] = Non
     return out
 
 
-def run_backtest(prices: pd.DataFrame, weights_by_date: Dict[pd.Timestamp, pd.Series], rebalance_on: Optional[Iterable[pd.Timestamp]] = None) -> pd.DataFrame:
+def run_backtest(
+    prices: pd.DataFrame,
+    weights_by_date: Dict[pd.Timestamp, pd.Series],
+    rebalance_on: Optional[Iterable[pd.Timestamp]] = None,
+) -> pd.DataFrame:
     """
     Simple backtest: compute daily returns from prices (forward returns between rebalances) and apply target weights.
     - `prices` is a DataFrame indexed by date with asset columns
@@ -40,7 +51,9 @@ def run_backtest(prices: pd.DataFrame, weights_by_date: Dict[pd.Timestamp, pd.Se
     returns = prices.pct_change().fillna(0)
 
     # ensure rebalance dates present
-    rebalance_dates = sorted(weights_by_date.keys()) if rebalance_on is None else sorted(rebalance_on)
+    rebalance_dates = (
+        sorted(weights_by_date.keys()) if rebalance_on is None else sorted(rebalance_on)
+    )
 
     pv = pd.Series(index=prices.index, dtype=float)
     turnover = pd.Series(0.0, index=rebalance_dates)
@@ -50,9 +63,15 @@ def run_backtest(prices: pd.DataFrame, weights_by_date: Dict[pd.Timestamp, pd.Se
 
     for dt in prices.index:
         if dt in rebalance_dates:
-            target = weights_by_date.get(dt, pd.Series(dtype=float)).reindex(prices.columns).fillna(0.0)
+            target = (
+                weights_by_date.get(dt, pd.Series(dtype=float))
+                .reindex(prices.columns)
+                .fillna(0.0)
+            )
             # compute turnover as sum of absolute differences
-            turnover.loc[dt] = (current_w.reindex(target.index).fillna(0.0) - target).abs().sum()
+            turnover.loc[dt] = (
+                (current_w.reindex(target.index).fillna(0.0) - target).abs().sum()
+            )
             current_w = target
         # apply daily returns
         r = (current_w * returns.loc[dt]).sum()

--- a/src/fetchers/_utils.py
+++ b/src/fetchers/_utils.py
@@ -1,4 +1,5 @@
 """Small utilities for fetchers: timing, retry/backoff, and cache key generation."""
+
 import time
 import hashlib
 import json
@@ -9,7 +10,9 @@ def time_ms():
     return int(time.time() * 1000)
 
 
-def simple_backoff_retry(fn: Callable[..., Any], attempts: int = 3, base_delay: float = 0.5) -> Any:
+def simple_backoff_retry(
+    fn: Callable[..., Any], attempts: int = 3, base_delay: float = 0.5
+) -> Any:
     """Call fn with simple exponential backoff. Returns fn() result or raises the last exception.
 
     This is intentionally simple: it retries on any Exception. The previous
@@ -23,7 +26,7 @@ def simple_backoff_retry(fn: Callable[..., Any], attempts: int = 3, base_delay: 
             return fn()
         except Exception as e:
             last_exc = e
-            delay = base_delay * (2 ** i)
+            delay = base_delay * (2**i)
             time.sleep(delay)
     # Re-raise the last caught exception
     if last_exc is None:
@@ -32,5 +35,15 @@ def simple_backoff_retry(fn: Callable[..., Any], attempts: int = 3, base_delay: 
 
 
 def cache_key_for_sdmx(source: str, resource: str, key: str, start: str, end: str):
-    payload = json.dumps({"source": source, "resource": resource, "key": key, "start": start, "end": end}, sort_keys=True, separators=(",", ":"))
+    payload = json.dumps(
+        {
+            "source": source,
+            "resource": resource,
+            "key": key,
+            "start": start,
+            "end": end,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    )
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()

--- a/src/fetchers/ecb.py
+++ b/src/fetchers/ecb.py
@@ -3,6 +3,7 @@
 Uses pandasdmx when available. Returns an empty DataFrame and a fetch_log
 when pandasdmx is not installed so tests can run in CI without network.
 """
+
 import logging
 from typing import List, Dict
 import pandas as pd
@@ -113,6 +114,7 @@ class ECBFetcher(AbstractFetcher):
             except Exception as e:
                 logger.debug(f"ECB fetch error for {ind}: {e}")
                 from datetime import datetime, timezone
+
                 fetch_logs.append(
                     {
                         "request_url": f"sdmx://ECB/{ind.get('code')}",
@@ -125,7 +127,7 @@ class ECBFetcher(AbstractFetcher):
                         "fetch_timestamp": datetime.now(timezone.utc).isoformat(),
                         "indicator": ind.get("id"),
                         "country": None,
-                        "api_meta": {"resource": ind.get('code')},
+                        "api_meta": {"resource": ind.get("code")},
                         "no_backfill": False,
                         "error": str(e),
                     }

--- a/src/fetchers/mapping.py
+++ b/src/fetchers/mapping.py
@@ -4,6 +4,7 @@ Supports CSV mapping (simple example in data/series_mapping.csv). Exposes
 `load_series_mapping(path)` which returns a dict keyed by (provider,resource,series_code)
 and `lookup_indicator(mapping, provider, resource, series_code)` helper.
 """
+
 import csv
 from typing import Dict, Tuple, Optional, Any
 
@@ -20,14 +21,22 @@ def load_series_mapping(path: str) -> Dict[Tuple[str, str, str], Dict[str, Any]]
                 indicator = (r.get("indicator_id") or "").strip()
                 if not provider or not series:
                     continue
-                mapping[(provider, resource, series)] = {"indicator_id": indicator, "notes": r.get("notes")}
+                mapping[(provider, resource, series)] = {
+                    "indicator_id": indicator,
+                    "notes": r.get("notes"),
+                }
     except Exception:
         # return empty mapping on error to avoid breaking pipeline consumers
         return {}
     return mapping
 
 
-def lookup_indicator(mapping: Dict[Tuple[str, str, str], Dict[str, Any]], provider: str, resource: str, series_code: str) -> Optional[str]:
+def lookup_indicator(
+    mapping: Dict[Tuple[str, str, str], Dict[str, Any]],
+    provider: str,
+    resource: str,
+    series_code: str,
+) -> Optional[str]:
     key = (provider, resource or "", series_code)
     res = mapping.get(key)
     if res:

--- a/src/fetchers/oecd.py
+++ b/src/fetchers/oecd.py
@@ -3,6 +3,7 @@
 Uses pandasdmx when available. Returns an empty DataFrame and a fetch_log
 when pandasdmx is not installed so tests can run in CI without network.
 """
+
 import logging
 from typing import List, Dict
 import pandas as pd
@@ -112,6 +113,7 @@ class OECDFetcher(AbstractFetcher):
             except Exception as e:
                 logger.debug(f"OECD fetch error for {ind}: {e}")
                 from datetime import datetime, timezone
+
                 fetch_logs.append(
                     {
                         "request_url": f"sdmx://OECD/{ind.get('code')}",
@@ -124,7 +126,7 @@ class OECDFetcher(AbstractFetcher):
                         "fetch_timestamp": datetime.now(timezone.utc).isoformat(),
                         "indicator": ind.get("id"),
                         "country": None,
-                        "api_meta": {"resource": ind.get('code')},
+                        "api_meta": {"resource": ind.get("code")},
                         "no_backfill": False,
                         "error": str(e),
                     }

--- a/src/fetchers/worldbank.py
+++ b/src/fetchers/worldbank.py
@@ -67,7 +67,12 @@ class WorldBankFetcher(AbstractFetcher):
         fetch_logs: list[dict] = []
         # defensive: if indicators is None or empty, return empty structures
         if not indicators:
-            return pd.DataFrame(columns=["source", "indicator", "country", "date", "value"]), fetch_logs
+            return (
+                pd.DataFrame(
+                    columns=["source", "indicator", "country", "date", "value"]
+                ),
+                fetch_logs,
+            )
         for ind in indicators:
             code = ind["code"]
             for country in countries:
@@ -91,6 +96,7 @@ class WorldBankFetcher(AbstractFetcher):
                         # log and append a canonical error entry then break
                         logger.warning(f"WB fetch error for {country}/{code}: {e}")
                         from datetime import datetime, timezone
+
                         fetch_logs.append(
                             {
                                 "request_url": url,
@@ -100,7 +106,9 @@ class WorldBankFetcher(AbstractFetcher):
                                 "rows": 0,
                                 "sha256_raw": None,
                                 "sha256_normalized": None,
-                                "fetch_timestamp": datetime.now(timezone.utc).isoformat(),
+                                "fetch_timestamp": datetime.now(
+                                    timezone.utc
+                                ).isoformat(),
                                 "indicator": ind.get("id"),
                                 "country": country,
                                 "api_meta": None,

--- a/src/io/cache.py
+++ b/src/io/cache.py
@@ -53,7 +53,9 @@ def cache_get(key: str, ttl_hours: int = 24) -> Optional[Dict[str, Any]]:
                             keyt = (ind, c)
                             if keyt not in series_map or ts > series_map[keyt]:
                                 series_map[keyt] = ts
-                        data["series_as_of"] = {f"{k[0]}::{k[1]}": v for k, v in series_map.items()}
+                        data["series_as_of"] = {
+                            f"{k[0]}::{k[1]}": v for k, v in series_map.items()
+                        }
                     except Exception:
                         data["series_as_of"] = {}
                 return data

--- a/src/portfolio/mapping.py
+++ b/src/portfolio/mapping.py
@@ -12,7 +12,11 @@ def load_country_mapping(path: str) -> Dict[str, Dict[str, str]]:
         with open(path, newline="", encoding="utf-8") as fh:
             reader = csv.DictReader(fh)
             for row in reader:
-                code = (row.get("iso3") or row.get("ISO3") or row.get("code") or "").strip().upper()
+                code = (
+                    (row.get("iso3") or row.get("ISO3") or row.get("code") or "")
+                    .strip()
+                    .upper()
+                )
                 if not code:
                     continue
                 out[code] = {k: v for k, v in row.items() if v is not None}
@@ -23,7 +27,9 @@ def load_country_mapping(path: str) -> Dict[str, Dict[str, str]]:
     return out
 
 
-def get_mapping_for_country(mapping: Dict[str, Dict[str, str]], iso3: str) -> Optional[Dict[str, str]]:
+def get_mapping_for_country(
+    mapping: Dict[str, Dict[str, str]], iso3: str
+) -> Optional[Dict[str, str]]:
     if not iso3:
         return None
     return mapping.get(str(iso3).upper())

--- a/src/portfolio/rebalance.py
+++ b/src/portfolio/rebalance.py
@@ -17,12 +17,19 @@ def compute_target_weights(
     mapping is not strictly required for weight computation but passed through for future extensions.
     """
     w = threshold_power_weights(
-        scores, threshold=threshold, power=power, min_alloc=min_alloc, max_alloc=max_alloc, top_n=top_n
+        scores,
+        threshold=threshold,
+        power=power,
+        min_alloc=min_alloc,
+        max_alloc=max_alloc,
+        top_n=top_n,
     )
     return w
 
 
-def apply_turnover_costs(weights_old: pd.Series, weights_new: pd.Series, cost_per_unit: float = 0.001) -> float:
+def apply_turnover_costs(
+    weights_old: pd.Series, weights_new: pd.Series, cost_per_unit: float = 0.001
+) -> float:
     """Compute turnover cost given previous and new weights; returns total cost fraction.
 
     cost_per_unit is cost per absolute weight change (e.g., 0.001 = 10 bps per 100% turnover)

--- a/src/portfolio/risk.py
+++ b/src/portfolio/risk.py
@@ -1,7 +1,9 @@
 import pandas as pd
 
 
-def compute_turnover_costs(weights_old: pd.Series, weights_new: pd.Series, cost_per_unit: float = 0.001) -> float:
+def compute_turnover_costs(
+    weights_old: pd.Series, weights_new: pd.Series, cost_per_unit: float = 0.001
+) -> float:
     """Compute estimated turnover cost fraction between two weight vectors.
 
     weights_old/new: pd.Series indexed by country codes. cost_per_unit is fraction per unit turnover.

--- a/src/portfolio/weights.py
+++ b/src/portfolio/weights.py
@@ -35,7 +35,9 @@ def threshold_power_weights(
     tilted_series = pd.Series(tilted, index=trimmed.index)
 
     # delegate the normalization and clamping to existing helper
-    weights = score_to_weights(tilted_series, min_alloc=min_alloc, max_alloc=max_alloc, top_n=top_n)
+    weights = score_to_weights(
+        tilted_series, min_alloc=min_alloc, max_alloc=max_alloc, top_n=top_n
+    )
     # drop zero (or near-zero) weights so returned series only contains active holdings
     if weights.empty:
         return weights

--- a/src/transforms/pipeline.py
+++ b/src/transforms/pipeline.py
@@ -52,9 +52,11 @@ def apply_standardization(
 
         # optionally use rolling MAD as scale for robust zscore
         rolling_mad = None
-        if getattr(cfg, 'rolling_mad', False):
+        if getattr(cfg, "rolling_mad", False):
             try:
-                rm = standardize.rolling_mad(s, window=cfg.rolling_window, min_periods=cfg.rolling_min_periods)
+                rm = standardize.rolling_mad(
+                    s, window=cfg.rolling_window, min_periods=cfg.rolling_min_periods
+                )
                 # align to dev index and fillna (use bfill/ffill to avoid deprecated fillna(method=...))
                 rolling_mad = rm.bfill().ffill().values
             except Exception:
@@ -62,13 +64,17 @@ def apply_standardization(
 
         # winsorize if requested
         if method in ("winsorized_zscore", "robust_zscore", "zscore"):
-            w = standardize.winsorize(dev, lower_pct=cfg.winsor_lower, upper_pct=cfg.winsor_upper)
+            w = standardize.winsorize(
+                dev, lower_pct=cfg.winsor_lower, upper_pct=cfg.winsor_upper
+            )
         else:
             w = dev
 
         # standardize methods
         if method == "robust_zscore":
-            z = standardize.robust_zscore(w, scale=rolling_mad if rolling_mad is not None else None)
+            z = standardize.robust_zscore(
+                w, scale=rolling_mad if rolling_mad is not None else None
+            )
         elif method == "zscore":
             # classic zscore: mean/std
             a = np.asarray(w, dtype=float)

--- a/src/transforms/standardize.py
+++ b/src/transforms/standardize.py
@@ -3,7 +3,9 @@ import numpy as np
 import pandas as pd
 
 
-def robust_zscore(arr: Iterable[float], center: Optional[float] = None, scale: Optional[float] = None):
+def robust_zscore(
+    arr: Iterable[float], center: Optional[float] = None, scale: Optional[float] = None
+):
     a = np.asarray(list(arr), dtype=float)
     if center is None:
         center = np.nanmedian(a)
@@ -25,7 +27,12 @@ def robust_zscore(arr: Iterable[float], center: Optional[float] = None, scale: O
 def rolling_mad(series: pd.Series, window: int = 12, min_periods: int = 3):
     """Return rolling MAD scaled to be comparable to std (1.4826 factor)."""
     med = series.rolling(window=window, min_periods=min_periods).median()
-    mad = series.subtract(med).abs().rolling(window=window, min_periods=min_periods).median()
+    mad = (
+        series.subtract(med)
+        .abs()
+        .rolling(window=window, min_periods=min_periods)
+        .median()
+    )
     return mad * 1.4826
 
 
@@ -40,7 +47,7 @@ def rank_norm(arr: Iterable[float]):
     a = np.asarray(list(arr), dtype=float)
     # rank, convert to uniform [0,1], then to standard normal via inverse CDF
     s = pd.Series(a)
-    ranks = s.rank(method='average', na_option='keep')
+    ranks = s.rank(method="average", na_option="keep")
     uniform = (ranks - 0.5) / ranks.count()
     # avoid exact 0/1
     eps = np.finfo(float).eps

--- a/tests/test_artifacts_env.py
+++ b/tests/test_artifacts_env.py
@@ -1,0 +1,51 @@
+import sys
+import json
+import hashlib
+import hmac
+from pathlib import Path
+
+# ensure project root is importable when tests run in isolation
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from src.io.artifacts import write_manifest, sha256_of_file
+
+
+def test_manifest_signing_and_output_hash(tmp_path, monkeypatch):
+    # create a dummy output file
+    out_file = tmp_path / "out.csv"
+    out_file.write_text("a,b,c\n1,2,3\n")
+
+    # set a deterministic signing key
+    monkeypatch.setenv("MANIFEST_SIGNING_KEY", "test-signing-key")
+
+    manifest = {
+        "config_snapshot": {"a": 1},
+        "fetch_summary": {},
+        "fetches": [],
+        "n_rows": 0,
+    }
+
+    path = write_manifest(
+        manifest, prefix="test_manifest", outputs={"csv": str(out_file)}
+    )
+    assert Path(path).exists()
+
+    m = json.loads(Path(path).read_text(encoding="utf-8"))
+    # signature must be present
+    assert "manifest_signature" in m
+    sig = m["manifest_signature"]
+
+    # recompute expected signature from stable payload
+    stable_keys = ["config_snapshot", "fetch_summary", "fetches", "n_rows", "outputs"]
+    stable_payload = {k: m.get(k) for k in stable_keys if k in m}
+    canonical = json.dumps(
+        stable_payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False
+    ).encode("utf-8")
+    expected = hmac.new(b"test-signing-key", canonical, hashlib.sha256).hexdigest()
+    assert sig == expected
+
+    # outputs hash was included and matches file
+    assert "outputs" in m
+    out_entry = m["outputs"].get("csv")
+    assert out_entry and out_entry["sha256"] == sha256_of_file(str(out_file))

--- a/tests/test_backtest.py
+++ b/tests/test_backtest.py
@@ -35,7 +35,9 @@ def test_backtest_basic_run():
     for i, d in enumerate(dates):
         signals.loc[d] = [1.0 + 0.01 * i, 0.5, 0.2]
 
-    weights_by_date = compute_rebalanced_weights(signals, top_n=2, min_alloc=0.0, max_alloc=0.8)
+    weights_by_date = compute_rebalanced_weights(
+        signals, top_n=2, min_alloc=0.0, max_alloc=0.8
+    )
     # ensure we have weights for each date
     assert len(weights_by_date) == len(dates)
 

--- a/tests/test_backtest_excel_integration.py
+++ b/tests/test_backtest_excel_integration.py
@@ -7,14 +7,30 @@ def test_export_excel_includes_backtest_and_portfolio():
     from src.io.excel import export_to_excel
 
     # create small ranking, indicators, raw and backtest/portfolio frames
-    ranking = pd.DataFrame({"country": ["USA", "DEU"], "score": [0.9, 0.1]}).set_index("country")
-    indicators = pd.DataFrame({"country": ["USA", "DEU"], "indicator": ["gdp", "gdp"], "value": [1.0, 0.5]})
-    raw = pd.DataFrame({"country": ["USA", "DEU"], "date": [pd.Timestamp("2020-01-01"), pd.Timestamp("2020-01-01")], "value": [1.0, 0.5]})
+    ranking = pd.DataFrame({"country": ["USA", "DEU"], "score": [0.9, 0.1]}).set_index(
+        "country"
+    )
+    indicators = pd.DataFrame(
+        {"country": ["USA", "DEU"], "indicator": ["gdp", "gdp"], "value": [1.0, 0.5]}
+    )
+    raw = pd.DataFrame(
+        {
+            "country": ["USA", "DEU"],
+            "date": [pd.Timestamp("2020-01-01"), pd.Timestamp("2020-01-01")],
+            "value": [1.0, 0.5],
+        }
+    )
 
-    backtest_df = pd.DataFrame({"date": pd.date_range("2020-01-01", periods=3), "nav": [1.0, 1.01, 1.02]})
+    backtest_df = pd.DataFrame(
+        {"date": pd.date_range("2020-01-01", periods=3), "nav": [1.0, 1.01, 1.02]}
+    )
     portfolio_df = pd.DataFrame({"country": ["USA", "DEU"], "weight": [0.6, 0.4]})
 
-    cfg = {"excel": {"number_format": "#.##0,00"}, "backtest": {"results": backtest_df}, "portfolio": {"allocations": portfolio_df}}
+    cfg = {
+        "excel": {"number_format": "#.##0,00"},
+        "backtest": {"results": backtest_df},
+        "portfolio": {"allocations": portfolio_df},
+    }
 
     tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".xlsx")
     tmp.close()

--- a/tests/test_backtest_unit.py
+++ b/tests/test_backtest_unit.py
@@ -6,10 +6,13 @@ def test_backtest_simple_positive_returns():
 
     dates = pd.date_range(start="2020-01-01", periods=5, freq="B")
     # two assets with steadily positive returns
-    prices = pd.DataFrame({
-        "A": [100, 101, 102, 103, 104],
-        "B": [50, 51, 52, 53, 54],
-    }, index=dates)
+    prices = pd.DataFrame(
+        {
+            "A": [100, 101, 102, 103, 104],
+            "B": [50, 51, 52, 53, 54],
+        },
+        index=dates,
+    )
 
     # signals: prefer asset A first day, then equal
     signals = pd.DataFrame(

--- a/tests/test_ecb_fetcher.py
+++ b/tests/test_ecb_fetcher.py
@@ -18,7 +18,7 @@ def make_fake_series():
         def __init__(self, series_list):
             self.series = series_list
 
-    s = SeriesObj({'REF_AREA': 'EMU'}, [Obs('2015', 100), Obs('2016', 110)])
+    s = SeriesObj({"REF_AREA": "EMU"}, [Obs("2015", 100), Obs("2016", 110)])
     r = types.SimpleNamespace(data=Data([s]))
     return r
 
@@ -33,19 +33,32 @@ def test_ecb_fetcher_basic(tmp_path, monkeypatch):
         def data(self, resource_id=None, key=None, startPeriod=None, endPeriod=None):
             return fake
 
-    with patch.dict('sys.modules'):
+    with patch.dict("sys.modules"):
         import sys
-        sys.modules['pandasdmx'] = types.SimpleNamespace(Request=lambda _: FakeClient())
+
+        sys.modules["pandasdmx"] = types.SimpleNamespace(Request=lambda _: FakeClient())
 
         from src.fetchers.ecb import ECBFetcher
 
         f = ECBFetcher()
-        df, logs = f.fetch(countries=['EMU'], indicators=[{'id':'EXR','code':'EMU.EXR.1','resource':'EXR'}], start='2015-01-01', end='2016-12-31', freq='A')
+        df, logs = f.fetch(
+            countries=["EMU"],
+            indicators=[{"id": "EXR", "code": "EMU.EXR.1", "resource": "EXR"}],
+            start="2015-01-01",
+            end="2016-12-31",
+            freq="A",
+        )
 
         assert isinstance(df, pd.DataFrame)
         assert len(df) == 2
-        assert any(entry.get('indicator') == 'EXR' for entry in logs)
+        assert any(entry.get("indicator") == "EXR" for entry in logs)
 
         # cache hit on second call
-        df2, logs2 = f.fetch(countries=['EMU'], indicators=[{'id':'EXR','code':'EMU.EXR.1','resource':'EXR'}], start='2015-01-01', end='2016-12-31', freq='A')
+        df2, logs2 = f.fetch(
+            countries=["EMU"],
+            indicators=[{"id": "EXR", "code": "EMU.EXR.1", "resource": "EXR"}],
+            start="2015-01-01",
+            end="2016-12-31",
+            freq="A",
+        )
         assert len(df2) == 2

--- a/tests/test_excel_portfolio_mapping.py
+++ b/tests/test_excel_portfolio_mapping.py
@@ -16,11 +16,31 @@ def test_excel_portfolio_mapping(tmp_path, monkeypatch):
         fh.write("USA,SPY,US78462F1030,NYSE,USD\n")
         fh.write("DEU,EWG,US4642871849,NYSE,USD\n")
 
-    ranked = pd.DataFrame({"score": [1.0, 0.5]}, index=["USA", "DEU"]) 
-    indicators_df = pd.DataFrame({"country": ["USA","DEU"], "indicator": ["i1","i2"], "date": ["2020-01-01","2020-01-01"], "value": [1,2]})
+    ranked = pd.DataFrame({"score": [1.0, 0.5]}, index=["USA", "DEU"])
+    indicators_df = pd.DataFrame(
+        {
+            "country": ["USA", "DEU"],
+            "indicator": ["i1", "i2"],
+            "date": ["2020-01-01", "2020-01-01"],
+            "value": [1, 2],
+        }
+    )
     raw_df = indicators_df.copy()
-    cfg = {"excel": {"path": str(tmp_path / "test.xlsx")}, "portfolio": {"allocations": pd.DataFrame({"country": ["USA","DEU"], "weight": [0.6, 0.4], "prev_weight": [0.5, 0.5]})}}
-    out = export_to_excel(str(tmp_path / "test.xlsx"), ranked, indicators_df, raw_df, cfg)
+    cfg = {
+        "excel": {"path": str(tmp_path / "test.xlsx")},
+        "portfolio": {
+            "allocations": pd.DataFrame(
+                {
+                    "country": ["USA", "DEU"],
+                    "weight": [0.6, 0.4],
+                    "prev_weight": [0.5, 0.5],
+                }
+            )
+        },
+    }
+    out = export_to_excel(
+        str(tmp_path / "test.xlsx"), ranked, indicators_df, raw_df, cfg
+    )
     # open and check Portfolio sheet exists and contains ticker/isin
     wb = load_workbook(out)
     assert "Portfolio" in wb.sheetnames

--- a/tests/test_excel_ranking_ci.py
+++ b/tests/test_excel_ranking_ci.py
@@ -12,12 +12,14 @@ from src.io.excel import export_to_excel
 
 def test_export_ranking_with_ci(tmp_path):
     # build a simple ranked df with CI and stability
-    ranked = pd.DataFrame({
-        "score": {"A": 1.0, "B": 0.5},
-        "score_ci_low": {"A": 0.9, "B": 0.4},
-        "score_ci_high": {"A": 1.1, "B": 0.6},
-        "rank_stability": {"A": 0.95, "B": 0.6},
-    })
+    ranked = pd.DataFrame(
+        {
+            "score": {"A": 1.0, "B": 0.5},
+            "score_ci_low": {"A": 0.9, "B": 0.4},
+            "score_ci_high": {"A": 1.1, "B": 0.6},
+            "rank_stability": {"A": 0.95, "B": 0.6},
+        }
+    )
     indicators_df = pd.DataFrame()
     raw_df = pd.DataFrame()
     out = tmp_path / "test_ranking.xlsx"

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -25,7 +25,7 @@ def test_robust_zscore_rolling_window():
     vals = [1, 2, 2, 3, 100]
     df = pd.DataFrame(
         {
-                "date": pd.date_range(start="2020-01-01", periods=len(vals), freq="ME"),
+            "date": pd.date_range(start="2020-01-01", periods=len(vals), freq="ME"),
             "value": vals,
         }
     )

--- a/tests/test_harmonize.py
+++ b/tests/test_harmonize.py
@@ -3,37 +3,41 @@ from src.processing.harmonize import harmonize_indicator, harmonize_df
 
 
 def test_annual_to_quarter_padding():
-    df = pd.DataFrame({
-        'date': pd.to_datetime(['2018-12-31', '2019-12-31', '2020-12-31']),
-        'value': [10.0, 20.0, 30.0]
-    })
-    out, rep = harmonize_indicator(df, target_freq='Q', aggregation='mean')
+    df = pd.DataFrame(
+        {
+            "date": pd.to_datetime(["2018-12-31", "2019-12-31", "2020-12-31"]),
+            "value": [10.0, 20.0, 30.0],
+        }
+    )
+    out, rep = harmonize_indicator(df, target_freq="Q", aggregation="mean")
     # expect quarterly rows covering years
-    assert rep['source_freq'] == 'A'
-    assert rep['target_freq'] == 'Q'
+    assert rep["source_freq"] == "A"
+    assert rep["target_freq"] == "Q"
     # 2018-12-31 -> 2018Q4 through 2020Q4 inclusive = 9 quarters
     assert len(out) == 9
     # every quarter value should be one of the annual values
-    assert set(out['value'].unique()).issubset({10.0, 20.0, 30.0})
+    assert set(out["value"].unique()).issubset({10.0, 20.0, 30.0})
 
 
 def test_monthly_to_quarter_aggregation():
-    dates = pd.date_range('2020-01-01', periods=6, freq='ME')
-    df = pd.DataFrame({'date': dates, 'value': [1, 2, 3, 4, 5, 6]})
-    out, rep = harmonize_indicator(df, target_freq='Q', aggregation='mean')
-    assert rep['source_freq'] == 'M'
+    dates = pd.date_range("2020-01-01", periods=6, freq="ME")
+    df = pd.DataFrame({"date": dates, "value": [1, 2, 3, 4, 5, 6]})
+    out, rep = harmonize_indicator(df, target_freq="Q", aggregation="mean")
+    assert rep["source_freq"] == "M"
     assert len(out) == 2  # six months -> 2 quarters
     # first quarter mean = (1+2+3)/3 = 2
-    assert out.iloc[0]['value'] == 2.0
+    assert out.iloc[0]["value"] == 2.0
 
 
 def test_harmonize_df_integration():
-    df = pd.DataFrame({
-        'indicator': ['i1'] * 6,
-        'country': ['AAA'] * 6,
-    'date': pd.date_range('2020-01-01', periods=6, freq='ME'),
-        'value': [1, 2, 3, 4, 5, 6]
-    })
-    out_df, rep_df = harmonize_df(df, target_freq='Q', aggregation='mean')
-    assert 'indicator' in out_df.columns and 'country' in out_df.columns
+    df = pd.DataFrame(
+        {
+            "indicator": ["i1"] * 6,
+            "country": ["AAA"] * 6,
+            "date": pd.date_range("2020-01-01", periods=6, freq="ME"),
+            "value": [1, 2, 3, 4, 5, 6],
+        }
+    )
+    out_df, rep_df = harmonize_df(df, target_freq="Q", aggregation="mean")
+    assert "indicator" in out_df.columns and "country" in out_df.columns
     assert not rep_df.empty

--- a/tests/test_imf_fetcher.py
+++ b/tests/test_imf_fetcher.py
@@ -20,7 +20,7 @@ def make_fake_series():
             self.series = series_list
 
     # Build a single series with two observations
-    s = SeriesObj({'REF_AREA': 'ABC'}, [Obs('2000', 1.23), Obs('2001', 2.34)])
+    s = SeriesObj({"REF_AREA": "ABC"}, [Obs("2000", 1.23), Obs("2001", 2.34)])
     r = types.SimpleNamespace(data=Data([s]))
     return r
 
@@ -37,22 +37,34 @@ def test_imf_fetcher_basic(tmp_path, monkeypatch):
         def data(self, resource_id=None, key=None, startPeriod=None, endPeriod=None):
             return fake
 
-    with patch.dict('sys.modules'):
+    with patch.dict("sys.modules"):
         # create a fake pandasdmx module with Request
         import sys
 
         mod = types.SimpleNamespace(Request=lambda source: FakeClient())
-        sys.modules['pandasdmx'] = mod
+        sys.modules["pandasdmx"] = mod
 
         from src.fetchers.imf import IMFFetcher
 
         f = IMFFetcher()
-        df, logs = f.fetch(countries=['ABC'], indicators=[{'id':'GDP','code':'ABC.GDP.1'}], start='2000-01-01', end='2001-12-31', freq='A')
+        df, logs = f.fetch(
+            countries=["ABC"],
+            indicators=[{"id": "GDP", "code": "ABC.GDP.1"}],
+            start="2000-01-01",
+            end="2001-12-31",
+            freq="A",
+        )
 
         assert isinstance(df, pd.DataFrame)
         assert len(df) == 2
-        assert any(entry.get('indicator') == 'GDP' for entry in logs)
+        assert any(entry.get("indicator") == "GDP" for entry in logs)
 
         # second call should hit cache (no exception) and return same shape
-        df2, logs2 = f.fetch(countries=['ABC'], indicators=[{'id':'GDP','code':'ABC.GDP.1'}], start='2000-01-01', end='2001-12-31', freq='A')
+        df2, logs2 = f.fetch(
+            countries=["ABC"],
+            indicators=[{"id": "GDP", "code": "ABC.GDP.1"}],
+            start="2000-01-01",
+            end="2001-12-31",
+            freq="A",
+        )
         assert len(df2) == 2

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -1,4 +1,5 @@
 import os
+
 # ruff: noqa
 import json
 import sys

--- a/tests/test_manifest_fields.py
+++ b/tests/test_manifest_fields.py
@@ -4,22 +4,31 @@ import glob
 
 
 def test_latest_manifest_has_env_and_fetch_fields():
-    art_dir = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'data', '_artifacts')
-    files = sorted(glob.glob(os.path.join(art_dir, '*.json')))
-    assert files, 'No manifest files found in data/_artifacts'
+    art_dir = os.path.join(
+        os.path.dirname(os.path.dirname(__file__)), "data", "_artifacts"
+    )
+    files = sorted(glob.glob(os.path.join(art_dir, "*.json")))
+    assert files, "No manifest files found in data/_artifacts"
     latest = files[-1]
-    with open(latest, encoding='utf-8') as fh:
+    with open(latest, encoding="utf-8") as fh:
         m = json.load(fh)
 
     # environment hash
-    assert 'environment' in m
-    assert 'env_hash' in m['environment']
+    assert "environment" in m
+    assert "env_hash" in m["environment"]
 
     # fetch entries
-    assert 'fetches' in m
-    assert isinstance(m['fetches'], list)
-    if m['fetches']:
-        sample = m['fetches'][0]
+    assert "fetches" in m
+    assert isinstance(m["fetches"], list)
+    if m["fetches"]:
+        sample = m["fetches"][0]
         # required keys
-        for k in ('request_url', 'http_status', 'response_time_ms', 'rows', 'sha256_normalized', 'fetch_timestamp'):
-            assert k in sample, f'Missing key {k} in fetch entry'
+        for k in (
+            "request_url",
+            "http_status",
+            "response_time_ms",
+            "rows",
+            "sha256_normalized",
+            "fetch_timestamp",
+        ):
+            assert k in sample, f"Missing key {k} in fetch entry"

--- a/tests/test_manifest_golden.py
+++ b/tests/test_manifest_golden.py
@@ -44,6 +44,8 @@ def test_manifest_golden(tmp_path):
     fe = fetches[0]
     assert fe.get("sha256_normalized") is not None
     assert fe.get("fetch_timestamp") == "2025-09-28T00:00:00Z"
+
+
 import sys
 import hashlib
 import hmac
@@ -55,15 +57,17 @@ if ROOT not in sys.path:
     sys.path.insert(0, ROOT)
 
 
-
 def canonical_payload(payload: dict) -> bytes:
-    return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+    return json.dumps(
+        payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False
+    ).encode("utf-8")
 
 
 def test_manifest_golden_signature(tmp_path, monkeypatch):
     # Load fixture records
     fixture = Path(__file__).parent / "fixtures" / "manifest_golden_records.json"
-    records = json.loads(fixture.read_text(encoding="utf-8"))
+    fixture_path = str(fixture)
+    records = json.loads(open(fixture_path, encoding="utf-8").read())
 
     fetch_entry = {
         "url": "https://api.example.org/gdp",
@@ -99,10 +103,12 @@ def test_manifest_golden_signature(tmp_path, monkeypatch):
     expected_sig = hmac.new(key, canonical, hashlib.sha256).hexdigest()
 
     assert m.get("manifest_signature") == expected_sig
+
+
 import sys
 
-ROOT = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(ROOT))
+ROOT2 = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT2))
 
 
 def test_manifest_hmac_stable(tmp_path, monkeypatch):

--- a/tests/test_manifest_hmac.py
+++ b/tests/test_manifest_hmac.py
@@ -7,38 +7,40 @@ from src.io import artifacts
 
 def test_manifest_hmac_signature(tmp_path, monkeypatch):
     # set a deterministic signing key
-    monkeypatch.setenv('MANIFEST_SIGNING_KEY', 'testkey123')
+    monkeypatch.setenv("MANIFEST_SIGNING_KEY", "testkey123")
 
     # construct a minimal stable manifest payload (only stable_keys will be signed)
     manifest = {
-        'config_snapshot': {'k': 1},
-        'fetch_summary': {'X': 1},
-        'fetches': [
+        "config_snapshot": {"k": 1},
+        "fetch_summary": {"X": 1},
+        "fetches": [
             {
-                'request_url': 'https://example.test/api',
-                'params': None,
-                'http_status': 200,
-                'response_time_ms': 10,
-                'rows': 1,
-                'sha256_normalized': 'deadbeef',
+                "request_url": "https://example.test/api",
+                "params": None,
+                "http_status": 200,
+                "response_time_ms": 10,
+                "rows": 1,
+                "sha256_normalized": "deadbeef",
             }
         ],
-        'n_rows': 1,
-        'outputs': {},
+        "n_rows": 1,
+        "outputs": {},
     }
 
-    out_path = artifacts.write_manifest(manifest, prefix='hmac_test')
+    out_path = artifacts.write_manifest(manifest, prefix="hmac_test")
     assert out_path and os.path.exists(out_path)
 
-    with open(out_path, encoding='utf-8') as fh:
+    with open(out_path, encoding="utf-8") as fh:
         m = json.load(fh)
 
     # manifest_signature must be present
-    assert 'manifest_signature' in m
+    assert "manifest_signature" in m
 
     # recompute expected signature over stable payload using same canonical JSON rules
-    stable_keys = ['config_snapshot', 'fetch_summary', 'fetches', 'n_rows', 'outputs']
+    stable_keys = ["config_snapshot", "fetch_summary", "fetches", "n_rows", "outputs"]
     stable_payload = {k: m.get(k) for k in stable_keys if k in m}
-    canonical = json.dumps(stable_payload, sort_keys=True, separators=(',', ':'), ensure_ascii=False).encode('utf-8')
-    expected = hmac.new(b'testkey123', canonical, hashlib.sha256).hexdigest()
-    assert m['manifest_signature'] == expected
+    canonical = json.dumps(
+        stable_payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False
+    ).encode("utf-8")
+    expected = hmac.new(b"testkey123", canonical, hashlib.sha256).hexdigest()
+    assert m["manifest_signature"] == expected

--- a/tests/test_manifest_strict.py
+++ b/tests/test_manifest_strict.py
@@ -5,8 +5,10 @@ from src.io import artifacts
 
 
 def _latest_manifest_path():
-    art_dir = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'data', '_artifacts')
-    files = sorted(glob.glob(os.path.join(art_dir, '*.json')))
+    art_dir = os.path.join(
+        os.path.dirname(os.path.dirname(__file__)), "data", "_artifacts"
+    )
+    files = sorted(glob.glob(os.path.join(art_dir, "*.json")))
     if not files:
         return None
     return files[-1]
@@ -20,13 +22,20 @@ def test_manifest_fetch_entries_strict():
     """
     path = _latest_manifest_path()
     if path:
-        with open(path, encoding='utf-8') as fh:
+        with open(path, encoding="utf-8") as fh:
             m = json.load(fh)
-        if m.get('validation', {}).get('n_issues', 0) == 0:
+        if m.get("validation", {}).get("n_issues", 0) == 0:
             # quick sanity: required keys present in first fetch entry
-            if m.get('fetches'):
-                f = m['fetches'][0]
-                for k in ('request_url', 'http_status', 'response_time_ms', 'rows', 'sha256_normalized', 'fetch_timestamp'):
+            if m.get("fetches"):
+                f = m["fetches"][0]
+                for k in (
+                    "request_url",
+                    "http_status",
+                    "response_time_ms",
+                    "rows",
+                    "sha256_normalized",
+                    "fetch_timestamp",
+                ):
                     assert k in f and f.get(k) is not None
                 return
 
@@ -34,7 +43,7 @@ def test_manifest_fetch_entries_strict():
     sample_records = [
         {"indicator": "TEST_IND", "country": "TST", "date": "2020", "value": 1}
     ]
-    raw_bytes = json.dumps(sample_records, ensure_ascii=False).encode('utf-8')
+    raw_bytes = json.dumps(sample_records, ensure_ascii=False).encode("utf-8")
     sample_fe = {
         "url": "https://example.test/api",
         "params": None,
@@ -57,8 +66,9 @@ def test_manifest_fetch_entries_strict():
     # write manifest (will populate environment + validation)
     path_out = artifacts.write_manifest(manifest, prefix="test_manifest_strict")
     assert os.path.exists(path_out)
-    with open(path_out, encoding='utf-8') as fh:
+    with open(path_out, encoding="utf-8") as fh:
         m2 = json.load(fh)
 
-    assert m2.get('validation', {}).get('n_issues', 0) == 0, f"Enriched manifest had validation issues: {m2.get('validation')}"
-
+    assert (
+        m2.get("validation", {}).get("n_issues", 0) == 0
+    ), f"Enriched manifest had validation issues: {m2.get('validation')}"

--- a/tests/test_manifest_validation_and_harmonize.py
+++ b/tests/test_manifest_validation_and_harmonize.py
@@ -21,7 +21,12 @@ def test_manifest_validation_includes_fetch_issues(tmp_path, monkeypatch):
         "country": "USA",
         # intentionally omit status_code and rows
     }
-    manifest = {"fetch_summary": {"X": 1}, "fetches": [fetch_entry], "n_rows": 1, "config_snapshot": {}}
+    manifest = {
+        "fetch_summary": {"X": 1},
+        "fetches": [fetch_entry],
+        "n_rows": 1,
+        "config_snapshot": {},
+    }
     monkeypatch.delenv("MANIFEST_SIGNING_KEY", raising=False)
     mpath = write_manifest(manifest, outputs={})
     m = json.loads(open(mpath, encoding="utf-8").read())

--- a/tests/test_oecd_fetcher.py
+++ b/tests/test_oecd_fetcher.py
@@ -18,7 +18,7 @@ def make_fake_series():
         def __init__(self, series_list):
             self.series = series_list
 
-    s = SeriesObj({'REF_AREA': 'XYZ'}, [Obs('2010', 10), Obs('2011', 11)])
+    s = SeriesObj({"REF_AREA": "XYZ"}, [Obs("2010", 10), Obs("2011", 11)])
     r = types.SimpleNamespace(data=Data([s]))
     return r
 
@@ -33,19 +33,32 @@ def test_oecd_fetcher_basic(tmp_path, monkeypatch):
         def data(self, resource_id=None, key=None, startPeriod=None, endPeriod=None):
             return fake
 
-    with patch.dict('sys.modules'):
+    with patch.dict("sys.modules"):
         import sys
-        sys.modules['pandasdmx'] = types.SimpleNamespace(Request=lambda _: FakeClient())
+
+        sys.modules["pandasdmx"] = types.SimpleNamespace(Request=lambda _: FakeClient())
 
         from src.fetchers.oecd import OECDFetcher
 
         f = OECDFetcher()
-        df, logs = f.fetch(countries=['XYZ'], indicators=[{'id':'IND1','code':'XYZ.IND1','resource':'MEI'}], start='2010-01-01', end='2011-12-31', freq='A')
+        df, logs = f.fetch(
+            countries=["XYZ"],
+            indicators=[{"id": "IND1", "code": "XYZ.IND1", "resource": "MEI"}],
+            start="2010-01-01",
+            end="2011-12-31",
+            freq="A",
+        )
 
         assert isinstance(df, pd.DataFrame)
         assert len(df) == 2
-        assert any(entry.get('indicator') == 'IND1' for entry in logs)
+        assert any(entry.get("indicator") == "IND1" for entry in logs)
 
         # Second call should use cache
-        df2, logs2 = f.fetch(countries=['XYZ'], indicators=[{'id':'IND1','code':'XYZ.IND1','resource':'MEI'}], start='2010-01-01', end='2011-12-31', freq='A')
+        df2, logs2 = f.fetch(
+            countries=["XYZ"],
+            indicators=[{"id": "IND1", "code": "XYZ.IND1", "resource": "MEI"}],
+            start="2010-01-01",
+            end="2011-12-31",
+            freq="A",
+        )
         assert len(df2) == 2

--- a/tests/test_per_indicator_override.py
+++ b/tests/test_per_indicator_override.py
@@ -3,12 +3,14 @@ from src.transforms.pipeline import apply_standardization
 
 
 def make_df(values):
-    return pd.DataFrame({
-        'indicator': ['test_ind'] * len(values),
-        'country': ['AAA'] * len(values),
-    'date': pd.date_range('2020-01-01', periods=len(values), freq='ME'),
-        'value': values,
-    })
+    return pd.DataFrame(
+        {
+            "indicator": ["test_ind"] * len(values),
+            "country": ["AAA"] * len(values),
+            "date": pd.date_range("2020-01-01", periods=len(values), freq="ME"),
+            "value": values,
+        }
+    )
 
 
 def test_per_indicator_override_changes_output():
@@ -16,37 +18,41 @@ def test_per_indicator_override_changes_output():
     df = make_df([1, 2, 3, 1000, 5, 6, 7])
 
     global_cfg = {
-        'winsor_lower': 0.01,
-        'winsor_upper': 0.99,
-        'rolling_window': 3,
-        'rolling_min_periods': 1,
+        "winsor_lower": 0.01,
+        "winsor_upper": 0.99,
+        "rolling_window": 3,
+        "rolling_min_periods": 1,
     }
 
     # per-indicator override with tight winsor bounds that will cap the outlier
     ind_override = {
-        'winsor_lower': 0.10,
-        'winsor_upper': 0.90,
-        'rolling_window': 3,
-        'rolling_min_periods': 1,
+        "winsor_lower": 0.10,
+        "winsor_upper": 0.90,
+        "rolling_window": 3,
+        "rolling_min_periods": 1,
     }
 
-    out_global = apply_standardization(df.copy(), config=global_cfg, method='robust_zscore')
-    out_override = apply_standardization(df.copy(), config=ind_override, method='robust_zscore')
+    out_global = apply_standardization(
+        df.copy(), config=global_cfg, method="robust_zscore"
+    )
+    out_override = apply_standardization(
+        df.copy(), config=ind_override, method="robust_zscore"
+    )
 
     # both should have produced a standardized column (std_value or value_std)
-    if 'std_value' in out_global.columns:
-        a = out_global['std_value']
-    elif 'value_std' in out_global.columns:
-        a = out_global['value_std']
+    if "std_value" in out_global.columns:
+        a = out_global["std_value"]
+    elif "value_std" in out_global.columns:
+        a = out_global["value_std"]
     else:
-        raise AssertionError('no standardized column in global output')
+        raise AssertionError("no standardized column in global output")
 
-    if 'std_value' in out_override.columns:
-        b = out_override['std_value']
-    elif 'value_std' in out_override.columns:
-        b = out_override['value_std']
+    if "std_value" in out_override.columns:
+        b = out_override["std_value"]
+    elif "value_std" in out_override.columns:
+        b = out_override["value_std"]
     else:
-        raise AssertionError('no standardized column in override output')
+        raise AssertionError("no standardized column in override output")
 
     # The presence of the large outlier should make the global result different
     # from the override where the outlier is winsorized more aggressively.

--- a/tests/test_pipeline_fixtures.py
+++ b/tests/test_pipeline_fixtures.py
@@ -10,7 +10,9 @@ def test_pipeline_runs_with_fixtures(tmp_path):
     if not os.path.isdir(out_dir):
         os.makedirs(out_dir, exist_ok=True)
     # run the script
-    res = subprocess.run(["python", "scripts/ci_fixture_run.py", cfg], capture_output=True, text=True)
+    res = subprocess.run(
+        ["python", "scripts/ci_fixture_run.py", cfg], capture_output=True, text=True
+    )
     print(res.stdout)
     # the runner should write the configured output file
     out_file = os.path.abspath("output/fixture_macro_ranking.xlsx")

--- a/tests/test_pipeline_integration.py
+++ b/tests/test_pipeline_integration.py
@@ -32,10 +32,16 @@ def test_pipeline_invert_and_rolling_mad():
     df_std_norm = apply_standardization(df, method="robust_zscore", invert=False)
     df_std_inv = apply_standardization(df, method="robust_zscore", invert=True)
     # pick first row for country A and same position for inverted run
-    a_norm = df_std_norm[(df_std_norm['country']=='A') & (df_std_norm['indicator']=='IND1')].iloc[0]['std_value']
-    a_inv = df_std_inv[(df_std_inv['country']=='A') & (df_std_inv['indicator']=='IND1')].iloc[0]['std_value']
+    a_norm = df_std_norm[
+        (df_std_norm["country"] == "A") & (df_std_norm["indicator"] == "IND1")
+    ].iloc[0]["std_value"]
+    a_inv = df_std_inv[
+        (df_std_inv["country"] == "A") & (df_std_inv["indicator"] == "IND1")
+    ].iloc[0]["std_value"]
     assert a_norm == -a_inv
 
     # test rolling_mad on (should run without error)
-    df_std_rm = apply_standardization(df, config={'rolling_mad': True}, method='robust_zscore')
-    assert 'std_value' in df_std_rm.columns
+    df_std_rm = apply_standardization(
+        df, config={"rolling_mad": True}, method="robust_zscore"
+    )
+    assert "std_value" in df_std_rm.columns

--- a/tests/test_sdmx_end_to_end.py
+++ b/tests/test_sdmx_end_to_end.py
@@ -5,6 +5,7 @@ import json
 import pytest
 from types import SimpleNamespace
 
+
 # reuse fixture loader
 def _load_fixture(name):
     p = f"tests/fixtures/{name}.json"
@@ -69,7 +70,9 @@ def test_sdmx_pipeline_end_to_end(tmp_path, inject_fake_pandasdmx, monkeypatch):
 
     # find the latest manifest in data/_artifacts
     artdir = os.path.join(os.getcwd(), "data", "_artifacts")
-    manifests = [os.path.join(artdir, p) for p in os.listdir(artdir) if p.endswith('.json')]
+    manifests = [
+        os.path.join(artdir, p) for p in os.listdir(artdir) if p.endswith(".json")
+    ]
     assert manifests, "No manifest files written"
     # pick the most recently modified manifest
     mpath = max(manifests, key=os.path.getmtime)

--- a/tests/test_sdmx_integration_more.py
+++ b/tests/test_sdmx_integration_more.py
@@ -66,7 +66,9 @@ from src.fetchers.ecb import ECBFetcher  # noqa: E402
 def test_sdmx_fetchers_multi_country():
     # Each fetcher should return a DataFrame and a fetch log list
     f_imf = IMFFetcher({})
-    df_imf, logs_imf = f_imf.fetch(["DEU"], [{"id": "x", "code": "c"}], "2020-01-01", "2024-01-01", "A")
+    df_imf, logs_imf = f_imf.fetch(
+        ["DEU"], [{"id": "x", "code": "c"}], "2020-01-01", "2024-01-01", "A"
+    )
     assert isinstance(df_imf, pd.DataFrame)
     assert isinstance(logs_imf, list)
     # logs should have normalized sha and timestamp
@@ -76,7 +78,9 @@ def test_sdmx_fetchers_multi_country():
             assert "fetch_timestamp" in ent
 
     f_oecd = OECDFetcher({})
-    df_oecd, logs_oecd = f_oecd.fetch(["DEU"], [{"id": "y", "code": "c2"}], "2020-01-01", "2024-01-01", "A")
+    df_oecd, logs_oecd = f_oecd.fetch(
+        ["DEU"], [{"id": "y", "code": "c2"}], "2020-01-01", "2024-01-01", "A"
+    )
     assert isinstance(df_oecd, pd.DataFrame)
     assert isinstance(logs_oecd, list)
     if logs_oecd:
@@ -85,7 +89,9 @@ def test_sdmx_fetchers_multi_country():
             assert "fetch_timestamp" in ent
 
     f_ecb = ECBFetcher({})
-    df_ecb, logs_ecb = f_ecb.fetch(["DEU"], [{"id": "z", "code": "c3"}], "2020-01-01", "2024-01-01", "A")
+    df_ecb, logs_ecb = f_ecb.fetch(
+        ["DEU"], [{"id": "z", "code": "c3"}], "2020-01-01", "2024-01-01", "A"
+    )
     assert isinstance(df_ecb, pd.DataFrame)
     assert isinstance(logs_ecb, list)
     if logs_ecb:

--- a/tests/test_sdmx_multi_country.py
+++ b/tests/test_sdmx_multi_country.py
@@ -62,7 +62,9 @@ from src.fetchers.ecb import ECBFetcher  # noqa: E402
 
 def test_imf_multi():
     f = IMFFetcher({})
-    df, logs = f.fetch(["DEU", "FRA"], [{"id": "i", "code": "c"}], "2019-01-01", "2024-01-01", "A")
+    df, logs = f.fetch(
+        ["DEU", "FRA"], [{"id": "i", "code": "c"}], "2019-01-01", "2024-01-01", "A"
+    )
     assert isinstance(df, pd.DataFrame)
     # should have rows for DEU and FRA
     assert set(df["country"]) >= {"DEU", "FRA"}
@@ -71,7 +73,9 @@ def test_imf_multi():
 
 def test_oecd_multi():
     f = OECDFetcher({})
-    df, logs = f.fetch(["DEU", "ITA"], [{"id": "o", "code": "c"}], "2019-01-01", "2022-01-01", "A")
+    df, logs = f.fetch(
+        ["DEU", "ITA"], [{"id": "o", "code": "c"}], "2019-01-01", "2022-01-01", "A"
+    )
     assert isinstance(df, pd.DataFrame)
     assert set(df["country"]) >= {"DEU", "ITA"}
     assert isinstance(logs, list)
@@ -79,7 +83,9 @@ def test_oecd_multi():
 
 def test_ecb_multi():
     f = ECBFetcher({})
-    df, logs = f.fetch(["DEU", "ESP"], [{"id": "e", "code": "c"}], "2018-01-01", "2021-01-01", "A")
+    df, logs = f.fetch(
+        ["DEU", "ESP"], [{"id": "e", "code": "c"}], "2018-01-01", "2021-01-01", "A"
+    )
     assert isinstance(df, pd.DataFrame)
     assert set(df["country"]) >= {"DEU", "ESP"}
     assert isinstance(logs, list)

--- a/tests/test_sdmx_vcr.py
+++ b/tests/test_sdmx_vcr.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 def _make_response_from_fixture(fixture_path):
     # Resolve fixture path relative to this test file so tests work when cwd changes
     import os
+
     base = os.path.dirname(__file__)
     # Try several candidate locations and pick the first that exists.
     candidates = []
@@ -18,11 +19,11 @@ def _make_response_from_fixture(fixture_path):
         candidates.append(os.path.join(base, fixture_path))
         # if given as tests/... strip leading 'tests/' or 'tests\\' then join
         rel = fixture_path
-        if rel.startswith('tests/') or rel.startswith('tests\\'):
+        if rel.startswith("tests/") or rel.startswith("tests\\"):
             try:
-                rel2 = rel.split('/', 1)[1]
+                rel2 = rel.split("/", 1)[1]
             except Exception:
-                rel2 = rel.split('\\', 1)[1]
+                rel2 = rel.split("\\", 1)[1]
             candidates.append(os.path.join(base, rel2))
 
     full = None
@@ -33,7 +34,7 @@ def _make_response_from_fixture(fixture_path):
     if full is None:
         # fallback to joining base and fixture_path (will raise the original error)
         full = os.path.join(base, fixture_path)
-    with open(full, 'r', encoding='utf-8') as f:
+    with open(full, "r", encoding="utf-8") as f:
         payload = json.load(f)
 
     # Build an object with .data.series where each series has .dimensions and .observations
@@ -53,9 +54,9 @@ def _make_response_from_fixture(fixture_path):
             self.series = series_list
 
     series_list = []
-    for s in payload.get('series', []):
-        dims = s.get('dimensions', {})
-        obs = s.get('observations', [])
+    for s in payload.get("series", []):
+        dims = s.get("dimensions", {})
+        obs = s.get("observations", [])
         series_list.append(SeriesObj(dims, obs))
 
     return types.SimpleNamespace(data=Data(series_list))
@@ -64,6 +65,7 @@ def _make_response_from_fixture(fixture_path):
 def test_sdmx_vcr_imf_oecd_ecb(tmp_path, monkeypatch):
     import sys
     import os
+
     # ensure project root is importable even after we change cwd
     base = os.path.dirname(__file__)
     project_root = os.path.dirname(base)
@@ -73,9 +75,9 @@ def test_sdmx_vcr_imf_oecd_ecb(tmp_path, monkeypatch):
     # ensure tests run in isolated tmp dir
     monkeypatch.chdir(tmp_path)
 
-    imf_resp = _make_response_from_fixture('tests/fixtures/imf_fixture.json')
-    oecd_resp = _make_response_from_fixture('tests/fixtures/oecd_fixture.json')
-    ecb_resp = _make_response_from_fixture('tests/fixtures/ecb_fixture.json')
+    imf_resp = _make_response_from_fixture("tests/fixtures/imf_fixture.json")
+    oecd_resp = _make_response_from_fixture("tests/fixtures/oecd_fixture.json")
+    ecb_resp = _make_response_from_fixture("tests/fixtures/ecb_fixture.json")
 
     class FakeIMF:
         def data(self, **kwargs):
@@ -89,9 +91,16 @@ def test_sdmx_vcr_imf_oecd_ecb(tmp_path, monkeypatch):
         def data(self, **kwargs):
             return ecb_resp
 
-    with patch.dict('sys.modules'):
+    with patch.dict("sys.modules"):
         import sys
-        sys.modules['pandasdmx'] = types.SimpleNamespace(Request=lambda source: FakeIMF() if source=='IMF' else (FakeOECD() if source=='OECD' else FakeECB()))
+
+        sys.modules["pandasdmx"] = types.SimpleNamespace(
+            Request=lambda source: (
+                FakeIMF()
+                if source == "IMF"
+                else (FakeOECD() if source == "OECD" else FakeECB())
+            )
+        )
 
         # import fetchers and call them to ensure they can process fixture payloads
         from src.fetchers.imf import IMFFetcher
@@ -99,13 +108,31 @@ def test_sdmx_vcr_imf_oecd_ecb(tmp_path, monkeypatch):
         from src.fetchers.ecb import ECBFetcher
 
         imf = IMFFetcher()
-        df_i, logs_i = imf.fetch(countries=['ABC'], indicators=[{'id':'GDP','code':'ABC.GDP.1'}], start='2000-01-01', end='2001-12-31', freq='A')
+        df_i, logs_i = imf.fetch(
+            countries=["ABC"],
+            indicators=[{"id": "GDP", "code": "ABC.GDP.1"}],
+            start="2000-01-01",
+            end="2001-12-31",
+            freq="A",
+        )
         assert len(df_i) == 2
 
         oecd = OECDFetcher()
-        df_o, logs_o = oecd.fetch(countries=['XYZ'], indicators=[{'id':'IND1','code':'XYZ.IND1','resource':'MEI'}], start='2010-01-01', end='2011-12-31', freq='A')
+        df_o, logs_o = oecd.fetch(
+            countries=["XYZ"],
+            indicators=[{"id": "IND1", "code": "XYZ.IND1", "resource": "MEI"}],
+            start="2010-01-01",
+            end="2011-12-31",
+            freq="A",
+        )
         assert len(df_o) == 2
 
         ecb = ECBFetcher()
-        df_e, logs_e = ecb.fetch(countries=['EMU'], indicators=[{'id':'EXR','code':'EMU.EXR.1','resource':'EXR'}], start='2015-01-01', end='2016-12-31', freq='A')
+        df_e, logs_e = ecb.fetch(
+            countries=["EMU"],
+            indicators=[{"id": "EXR", "code": "EMU.EXR.1", "resource": "EXR"}],
+            start="2015-01-01",
+            end="2016-12-31",
+            freq="A",
+        )
         assert len(df_e) == 2

--- a/tests/test_series_mapping.py
+++ b/tests/test_series_mapping.py
@@ -12,7 +12,7 @@ def test_load_and_lookup(tmp_path, monkeypatch):
 
     mapping = load_series_mapping(str(dst))
     assert mapping
-    ind = lookup_indicator(mapping, 'IMF', 'IFS', 'ABC.GDP.1')
-    assert ind == 'GDP'
-    ind2 = lookup_indicator(mapping, 'OECD', 'MEI', 'XYZ.IND1')
-    assert ind2 == 'IND1'
+    ind = lookup_indicator(mapping, "IMF", "IFS", "ABC.GDP.1")
+    assert ind == "GDP"
+    ind2 = lookup_indicator(mapping, "OECD", "MEI", "XYZ.IND1")
+    assert ind2 == "IND1"

--- a/tests/test_standardize.py
+++ b/tests/test_standardize.py
@@ -16,6 +16,7 @@ def test_winsorize_clip():
     w = standardize.winsorize(arr, lower_pct=0.0, upper_pct=0.75)
     # values should be clipped to the quantile bounds
     import numpy as np
+
     a = np.asarray(arr, dtype=float)
     high = np.nanquantile(a, 0.75)
     low = np.nanquantile(a, 0.0)

--- a/tests/test_standardize_methods.py
+++ b/tests/test_standardize_methods.py
@@ -3,22 +3,42 @@ from src.transforms.pipeline import apply_standardization
 
 
 def make_df(values):
-    return pd.DataFrame({
-        'indicator': ['t1'] * len(values),
-        'country': ['AAA'] * len(values),
-        'date': pd.date_range('2020-01-01', periods=len(values), freq='ME'),
-        'value': values,
-    })
+    return pd.DataFrame(
+        {
+            "indicator": ["t1"] * len(values),
+            "country": ["AAA"] * len(values),
+            "date": pd.date_range("2020-01-01", periods=len(values), freq="ME"),
+            "value": values,
+        }
+    )
 
 
 def test_winsorized_and_robust_zscore_differ():
     df = make_df([1, 2, 3, 1000, 5, 6, 7])
 
-    out_robust = apply_standardization(df.copy(), config={'winsor_lower': 0.01, 'winsor_upper': 0.99, 'rolling_window': 3, 'rolling_min_periods': 1}, method='robust_zscore')
-    out_wins = apply_standardization(df.copy(), config={'winsor_lower': 0.10, 'winsor_upper': 0.90, 'rolling_window': 3, 'rolling_min_periods': 1}, method='winsorized_zscore')
+    out_robust = apply_standardization(
+        df.copy(),
+        config={
+            "winsor_lower": 0.01,
+            "winsor_upper": 0.99,
+            "rolling_window": 3,
+            "rolling_min_periods": 1,
+        },
+        method="robust_zscore",
+    )
+    out_wins = apply_standardization(
+        df.copy(),
+        config={
+            "winsor_lower": 0.10,
+            "winsor_upper": 0.90,
+            "rolling_window": 3,
+            "rolling_min_periods": 1,
+        },
+        method="winsorized_zscore",
+    )
 
-    a = out_robust['std_value']
-    b = out_wins['std_value']
+    a = out_robust["std_value"]
+    b = out_wins["std_value"]
 
     # With stronger winsorization, at least one element should differ
     assert not a.equals(b)
@@ -28,12 +48,23 @@ def test_auto_sign_check_flips_when_needed():
     # construct a dev series where higher raw value is bad but good_direction='up'
     df = make_df([10, 9, 8, 7, 6, 5, 4])
     # here, higher raw value indicates worse outcome, so if good_direction='up' we expect flip
-    out = apply_standardization(df.copy(), config={'winsor_lower': 0.01, 'winsor_upper': 0.99, 'rolling_window': 3, 'rolling_min_periods': 1}, method='robust_zscore', good_direction='up', auto_sign_check=True)
+    out = apply_standardization(
+        df.copy(),
+        config={
+            "winsor_lower": 0.01,
+            "winsor_upper": 0.99,
+            "rolling_window": 3,
+            "rolling_min_periods": 1,
+        },
+        method="robust_zscore",
+        good_direction="up",
+        auto_sign_check=True,
+    )
 
     # compute spearman between dev and std — should be positive when good_direction matches, else flipped
-    s = out.set_index('date')
-    dev = s['value'] - s['value'].rolling(window=3, min_periods=1).median()
-    corr = dev.corr(s['std_value'], method='spearman')
+    s = out.set_index("date")
+    dev = s["value"] - s["value"].rolling(window=3, min_periods=1).median()
+    corr = dev.corr(s["std_value"], method="spearman")
 
     # since we forced good_direction='up' but actual dev is negatively sloped, we expect corr>0 after auto-flip
     assert corr is not None


### PR DESCRIPTION
Summary

Add pydantic compatibility helper and apply to key callsites.
Harden manifests: add manifest_version, environment snapshot (sidecar file), manifest SHA256 provenance and deterministic signing when MANIFEST_SIGNING_KEY is set.
Update CI: run ruff, mypy (blocking), pytest (upload junit artifact), pip-audit (blocking).
Add README pre-commit instructions and PR template.
How to test locally

python -m pip install --user pre-commit
python -m pre_commit install
python -m pre_commit run --all-files
pytest -q
Notes

I cleaned old environment sidecars in [_artifacts](vscode-file://vscode-app/c:/Users/david/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) (local files) to ensure tests find manifest JSON files correctly.